### PR TITLE
Add Sphinx Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,62 @@
+Python Zimbra
+=============
+
+Usage
+-----
+
+You can use ``ZimbraUser`` to send E-mails. You can send multiple
+E-mails within a single session.
+
+.. code:: python
+
+   from zimbra import ZimbraUser
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+   user.send_mail(to="receiver@example.com", subject="subject", body="body", cc="cc@example.com")
+   user.logout()
+
+Sending raw WebkitPayloads
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don’t want to rely on us to generate the payload, you can
+generate a payload yourself and send it using
+
+.. code:: python
+
+   from zimbra import ZimbraUser
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+
+   # you could also generate the payload yourself or use our library
+   raw_payload, boundary = user.generate_webkit_payload(to="to@example.com", subject="hello world!", body="this is a raw payload.") 
+
+   # then send the raw_payload bytes
+   user.send_raw_payload(raw_payload, boundary)
+
+   user.logout()
+
+Attachments
+~~~~~~~~~~~
+
+You can generate attachments using the ``WebkitAttachment`` class:
+
+.. code:: python
+
+   from zimbra import ZimbraUser, WebkitAttachment
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+
+   attachments = []
+   with open("myfile.jpg", "rb") as f:
+      attachments.append(WebkitAttachment(content=f.read(), filename="attachment.jpg"))
+
+   user.send_mail(to="receiver@example.com", subject="subject", body="body", attachments=attachments)
+   user.logout()
+
+Known Limitations
+-----------------
+
+-  Emoji is not supported, even though other UTF-8 characters are.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Python Zimbra Web'
+copyright = '2021, Cirosec Studis'
+author = 'Cirosec Studis'
+
+# The full version, including alpha/beta/rc tags
+release = '2.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.napoleon"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,88 @@
+.. Python Zimbra Web documentation master file, created by
+   sphinx-quickstart on Fri Oct 29 19:04:26 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Python Zimbra Web's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+
+
+Contents
+--------
+
+.. toctree::
+   zimbra
+
+Usage
+-----
+
+You can use :meth:`zimbra.ZimbraUser` to send E-mails. You can send multiple
+E-mails within a single session.
+
+.. code:: python
+
+   from zimbra import ZimbraUser
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+   user.send_mail(to="receiver@example.com", subject="subject", body="body", cc="cc@example.com")
+   user.logout()
+
+Sending raw WebkitPayloads
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don’t want to rely on us to generate the payload, you can
+generate a payload yourself and send it using :meth:`zimbra.ZimbraUser.send_raw_payload`.
+
+.. code:: python
+
+   from zimbra import ZimbraUser
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+
+   # you could also generate the payload yourself or use our library
+   raw_payload, boundary = user.generate_webkit_payload(to="to@example.com", subject="hello world!", body="this is a raw payload.") 
+
+   # then send the raw_payload bytes
+   user.send_raw_payload(raw_payload, boundary)
+
+   user.logout()
+
+Attachments
+~~~~~~~~~~~
+
+You can generate attachments using the :meth:`zimbra.WebkitAttachment` class:
+
+.. code:: python
+
+   from zimbra import ZimbraUser, WebkitAttachment
+
+   user = ZimbraUser("https://myzimbra.server")
+   user.login("s000000", "hunter2")
+
+   attachments = []
+   with open("myfile.jpg", "rb") as f:
+      attachments.append(WebkitAttachment(content=f.read(), filename="attachment.jpg"))
+
+   user.send_mail(to="receiver@example.com", subject="subject", body="body", attachments=attachments)
+   user.logout()
+
+Known Limitations
+-----------------
+
+-  Emoji is not supported, even though other UTF-8 characters are.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+zimbra
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   zimbra

--- a/docs/source/zimbra.rst
+++ b/docs/source/zimbra.rst
@@ -1,0 +1,9 @@
+zimbra package
+==============
+
+Module contents
+---------------
+
+.. automodule:: zimbra
+   :members:
+   :show-inheritance:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ pytest-cov==2.12.1
 mypy===0.910
 types-requests==2.25.11
 types-setuptools==57.4.2
+sphinx==4.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ testing =
     tox>=3.24
     types-request>=2.25
     types-setuptools>=57.4.2
+    sphinx>=4.2
 
 [options.package_data]
 zimbra = py.typed

--- a/src/zimbra/__init__.py
+++ b/src/zimbra/__init__.py
@@ -1,8 +1,3 @@
-"""
-
-"""
-
-
 import logging
 from typing import Optional, Dict, Tuple, List
 from dataclasses import dataclass, astuple
@@ -255,12 +250,20 @@ class ZimbraUser:
         """
         Sends a raw payload to the Web interface.
 
+        Examples:
+            >>> from zimbra import ZimbraUser
+            >>> user = ZimbraUser("https://my-zimbra.server")
+            >>> user.login("xxx", "xxx")
+            >>> payload, boundary = user.generate_webkit_payload(to="hello@example.com", subject="test mail", body="hello, world!")
+            >>> user.send_raw_payload(payload, boundary)
+            Response(success=True, status="Ihre Mail wurde gesendet.")
+
         Args:
             payload: bytes: The payload to send in the body of the request
             boundary: str: The boundary that is used in the WebkitFormBoundary payload
 
         Returns:
-            A zimbra.Response object with response.True if payload was sent successfully and the resposne message from the web client.
+            A zimbra.Response object with response.success == True if payload was sent successfully and the resposne message from the web client.
         """
         if not self.authenticated:
             return Response(False, "Not Authenticated")

--- a/src/zimbra/__init__.py
+++ b/src/zimbra/__init__.py
@@ -259,8 +259,8 @@ class ZimbraUser:
             Response(success=True, status="Ihre Mail wurde gesendet.")
 
         Args:
-            payload: bytes: The payload to send in the body of the request
-            boundary: str: The boundary that is used in the WebkitFormBoundary payload
+            payload (bytes): The payload to send in the body of the request
+            boundary (str): The boundary that is used in the WebkitFormBoundary payload
 
         Returns:
             A zimbra.Response object with response.success == True if payload was sent successfully and the resposne message from the web client.


### PR DESCRIPTION
This changes all the docstrings to be fully compatible with Google Style Docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html#example-google

Documentation can be built using
```
(env) $ sphinx-build -b html docs/source docs/build/html
[...]
The HTML pages are in docs\build\html.
```

Closes #36 